### PR TITLE
Replace `isort` with `reorder-python-imports`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,11 @@ repos:
         additional_dependencies:
         - flake8-click==0.3.1
         - flake8-bugbear==20.1.4
--   repo: https://github.com/PyCQA/isort.git
-    rev: 5.5.4
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.3.5
     hooks:
-    -   id: isort
+    -   id: reorder-python-imports
+        args: ["--application-directories", ".:src:Products:ZopeTree"]
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.6.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     -   id: reorder-python-imports
         args: ["--application-directories", ".:src:Products:ZopeTree"]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.6.2
+    rev: v2.7.2
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]

--- a/__init__.py
+++ b/__init__.py
@@ -6,11 +6,9 @@
 # This software is distributed under the terms of the Mozilla Public License
 # (MPL)
 #
-
 """
 $Id: __init__.py,v 1.5 2003/03/15 17:40:06 philipp Exp $
 """
-
 # make sure, 'from Interface import Interface' will work...
 try:
     from Interface import Interface
@@ -41,6 +39,6 @@ __roles__ = None
 from TreeObjectWrapper import TreeObjectWrapper  # noqa
 
 # make ZopeTree module accessible from PythonScript and ZPT
-from ZopeTree import Node, ZopeTree  # noqa  #isort:skip
+from ZopeTree import Node, ZopeTree  # noqa
 
 allow_module("Products.ZopeTree")

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import find_packages, setup
+from setuptools import find_packages
+from setuptools import setup
 
 setup(
     name="Products.ZopeTree",

--- a/src/Products/ZopeTree/IZopeTree.py
+++ b/src/Products/ZopeTree/IZopeTree.py
@@ -8,8 +8,8 @@
 # This software is distributed under the terms of the Mozilla Public
 # License (MPL)
 #
-
-from zope.interface import Attribute, Interface
+from zope.interface import Attribute
+from zope.interface import Interface
 
 
 class INode(Interface):

--- a/src/Products/ZopeTree/TreeObjectWrapper.py
+++ b/src/Products/ZopeTree/TreeObjectWrapper.py
@@ -6,11 +6,9 @@
 # This software is distributed under the terms of the Mozilla Public
 # License (MPL)
 #
-
 """
 $Id: TreeObjectWrapper.py,v 1.5 2003/04/30 10:01:55 philipp Exp $
 """
-
 import posixpath
 
 

--- a/src/Products/ZopeTree/ZopeTree.py
+++ b/src/Products/ZopeTree/ZopeTree.py
@@ -8,17 +8,17 @@
 # This software is distributed under the terms of the Mozilla Public
 # License (MPL)
 #
-
 """
 $Id: ZopeTree.py,v 1.8 2003/05/30 15:13:02 philipp Exp $
 """
-
 import zlib
 
 import zope.interface
-from ZTUtils.Tree import a2b, b2a
+from ZTUtils.Tree import a2b
+from ZTUtils.Tree import b2a
 
-from Products.ZopeTree.IZopeTree import INode, IZopeTree
+from Products.ZopeTree.IZopeTree import INode
+from Products.ZopeTree.IZopeTree import IZopeTree
 
 
 @zope.interface.implementer(INode)

--- a/src/Products/ZopeTree/__init__.py
+++ b/src/Products/ZopeTree/__init__.py
@@ -1,6 +1,3 @@
-"""
-isort:skip
-"""
 #
 # ZopeTree
 #
@@ -9,7 +6,6 @@ isort:skip
 # This software is distributed under the terms of the Mozilla Public License
 # (MPL)
 #
-
 from AccessControl import allow_module
 
 __allow_access_to_unprotected_subobjects__ = 1
@@ -18,6 +14,6 @@ __roles__ = None
 from Products.ZopeTree.TreeObjectWrapper import TreeObjectWrapper  # noqa
 
 # make ZopeTree module accessible from PythonScript and ZPT
-from Products.ZopeTree.ZopeTree import Node, ZopeTree  # noqa  # isort:skip
+from Products.ZopeTree.ZopeTree import Node, ZopeTree  # noqa
 
 allow_module("Products.ZopeTree")

--- a/src/Products/ZopeTree/tests/test_ZopeTree.py
+++ b/src/Products/ZopeTree/tests/test_ZopeTree.py
@@ -8,8 +8,10 @@ from ZPublisher.HTTPRequest import HTTPRequest
 from ZPublisher.HTTPResponse import HTTPResponse
 from ZTUtils.Tree import b2a
 
-from Products.ZopeTree import Node, ZopeTree
-from Products.ZopeTree.IZopeTree import INode, IZopeTree
+from Products.ZopeTree import Node
+from Products.ZopeTree import ZopeTree
+from Products.ZopeTree.IZopeTree import INode
+from Products.ZopeTree.IZopeTree import IZopeTree
 
 ZopeTestCase.installProduct("ZopeTree")
 


### PR DESCRIPTION
modified:   .pre-commit-config.yaml
modified:   __init__.py
modified:   setup.py
modified:   src/Products/ZopeTree/IZopeTree.py
modified:   src/Products/ZopeTree/TreeObjectWrapper.py
modified:   src/Products/ZopeTree/ZopeTree.py
modified:   src/Products/ZopeTree/__init__.py
modified:   src/Products/ZopeTree/tests/test_ZopeTree.py