### PR TITLE
Use Black profile

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -41,6 +41,6 @@ __roles__ = None
 from TreeObjectWrapper import TreeObjectWrapper  # noqa
 
 # make ZopeTree module accessible from PythonScript and ZPT
-from ZopeTree import Node, ZopeTree  # noqa  #isort:skip
+from ZopeTree import Node, ZopeTree  # noqa
 
 allow_module("Products.ZopeTree")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["setuptools>=41.6.0", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.isort]
+profile = "black"

--- a/src/Products/ZopeTree/__init__.py
+++ b/src/Products/ZopeTree/__init__.py
@@ -1,6 +1,3 @@
-"""
-isort:skip
-"""
 #
 # ZopeTree
 #
@@ -18,6 +15,6 @@ __roles__ = None
 from Products.ZopeTree.TreeObjectWrapper import TreeObjectWrapper  # noqa
 
 # make ZopeTree module accessible from PythonScript and ZPT
-from Products.ZopeTree.ZopeTree import Node, ZopeTree  # noqa  # isort:skip
+from Products.ZopeTree.ZopeTree import Node, ZopeTree  # noqa
 
 allow_module("Products.ZopeTree")


### PR DESCRIPTION
As a possible alternative to: https://github.com/jugmac00/Products.ZopeTree/pull/16. Updates project to use the black profile for isort. Additionally, removes some unnecessary skips that were present.

Independent of the approach you decide, one benefit of placing the configuration outside of pre-commit is that if you or a contributor uses a text editor that formats on save, there wont be unnecessary churn when a commit is made.
