### PR TITLE
Add support for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
 
 install:
   - pip install -U pip

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ v2.0.2.unreleased
 
   * drop support for Python versions < 3.6
 
+  * add support for Python 3.9
+
 v2.0.1
 
   * fix link to PyPi badge

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     packages=find_packages("src"),
     namespace_packages=["Products"],

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py36,
     py37,
     py38,
+    py39,
     pre-commit
 
 [testenv]


### PR DESCRIPTION
Travis uses `3.9-dev` until 3.9 is available there.

modified:   .travis.yml
modified:   CHANGES.txt
modified:   setup.py
modified:   tox.ini